### PR TITLE
feat: add ARM build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,11 +38,11 @@ jobs:
         OS: ["windows-latest", "macos-latest"]
         include:
           - os: macOS-latest
-            uploaded_filename: tgtg-x86_64-apple-darwin
-            local_path: artifacts/tgtg-x86_64-apple-darwin
+            uploaded_filename: tgtg-macos-amd64
+            local_path: artifacts/tgtg-macos-amd64
           - os: windows-latest
-            uploaded_filename: tgtg-x86_64-pc-win32.exe
-            local_path: artifacts/tgtg-x86_64-pc-win32.exe
+            uploaded_filename: tgtg-win-amd64.exe
+            local_path: artifacts/tgtg-win-amd64.exe
     steps:
       - uses: actions/checkout@v3
         with:
@@ -71,18 +71,14 @@ jobs:
     strategy:
       matrix:
         OS: ["ubuntu-latest"]
-        platform:
+        platforms:
           - linux/amd64
-          - linux/arm/v7
-          - linux/arm64/v8
+          - linux/arm/v7,linux/arm64/v8
         include:
-          - platform: linux/amd64
-            uploaded_filename: tgtg-x86_64-pc-linux
-            local_path: artifacts/tgtg-x86_64-pc-linux
-          - platform: linux/arm/v7
-            uploaded_filename: tgtg.jar
-            local_path: artifacts/tgtg.jar
-          - platform: linux/arm64/v8
+          - platforms: linux/amd64
+            uploaded_filename: tgtg-linux-amd64
+            local_path: artifacts/tgtg-linux-amd64
+          - platforms: linux/arm/v7,linux/arm64/v8
             uploaded_filename: tgtg.jar
             local_path: artifacts/tgtg.jar
     steps:
@@ -108,29 +104,29 @@ jobs:
           power: true
           jvm: "temurin:17"
       - name: Package app
-        if: matrix.platform == 'linux/amd64'
+        if: matrix.platforms == 'linux/amd64'
         run: scala-cli package . -o "${{ matrix.local_path }}" --native-image -- -H:IncludeResources=version.txt --static
       - name: Compress artifact
-        if: matrix.platform == 'linux/amd64'
+        if: matrix.platforms == 'linux/amd64'
         uses: crazy-max/ghaction-upx@v2
         with:
           args: --best
           files: ${{ matrix.local_path }}
       - name: Package app
-        if: matrix.platform != 'linux/amd64'
+        if: matrix.platforms != 'linux/amd64'
         run: |
-          mkdir -p $(dirname "${{  matrix.local_path }}")
+          mkdir -p $(dirname "${{ matrix.local_path }}")
           scala-cli package . -o "${{ matrix.local_path }}" --assembly
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         id: build
         with:
-          file: ${{ matrix.platform == 'linux/amd64' && './Dockerfile' || './arm.Dockerfile' }}
+          file: ${{ matrix.platforms == 'linux/amd64' && './Dockerfile' || './arm.Dockerfile' }}
           build-args: "LOCAL_PATH=${{ matrix.local_path }}"
           context: .
           push: true
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ matrix.platform }}
+          platforms: ${{ matrix.platforms }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
       - name: Export digest
         run: |
@@ -145,7 +141,6 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - uses: actions/upload-artifact@v3
-        if: matrix.platform == 'linux/arm64/v8' || matrix.platform == 'linux/amd64'
         with:
           name: ${{ matrix.uploaded_filename }}
           path: ${{ matrix.local_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,14 +35,11 @@ jobs:
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
-        OS: ["ubuntu-latest", "windows-latest", "macos-latest"]
+        OS: ["windows-latest", "macos-latest"]
         include:
           - os: macOS-latest
             uploaded_filename: tgtg-x86_64-apple-darwin
             local_path: artifacts/tgtg-x86_64-apple-darwin
-          - os: ubuntu-latest
-            uploaded_filename: tgtg-x86_64-pc-linux
-            local_path: artifacts/tgtg-x86_64-pc-linux
           - os: windows-latest
             uploaded_filename: tgtg-x86_64-pc-win32.exe
             local_path: artifacts/tgtg-x86_64-pc-win32.exe
@@ -50,71 +47,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Log in to the Container registry
-        if: matrix.OS == 'ubuntu-latest'
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Set up Docker Buildx
-        if: matrix.OS == 'ubuntu-latest'
-        uses: docker/setup-buildx-action@v2
-      - name: Extract metadata (tags, labels) for Docker
-        if: matrix.OS == 'ubuntu-latest'
-        id: meta
-        uses: docker/metadata-action@v4
-        with:
-          images: ${{ env.REGISTRY_IMAGE }}
-          # type=raw,value=${{ needs.release-please.outputs.tag_name }}
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=raw,value=latest
       - uses: coursier/cache-action@v6
       - uses: VirtusLab/scala-cli-setup@v1
         with:
           power: true
           jvm: "temurin:17"
       - name: Package app
-        if: matrix.OS != 'ubuntu-latest'
         run: scala-cli package . -o "${{ matrix.local_path }}" --native-image --graalvm-args -H:IncludeResources=version.txt
-      - name: Package app
-        if: matrix.OS == 'ubuntu-latest'
-        run: scala-cli package . -o "${{ matrix.local_path }}" --native-image -- -H:IncludeResources=version.txt --static
-      - name: Compress artifact
-        if: ${{ matrix.OS == 'ubuntu-latest' }}
-        uses: crazy-max/ghaction-upx@v2
-        with:
-          args: --best
-          files: ${{ matrix.local_path }}
-      - name: Build and push Docker image
-        if: matrix.OS == 'ubuntu-latest'
-        uses: docker/build-push-action@v4
-        id: build
-        with:
-          build-args: "LOCAL_PATH=${{ matrix.local_path }}"
-          context: .
-          push: true
-          labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/amd64
-          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
-      - name: Export digest
-        if: matrix.OS == 'ubuntu-latest'
-        run: |
-          mkdir -p /tmp/digests
-          digest="${{ steps.build.outputs.digest }}"
-          touch "/tmp/digests/${digest#sha256:}"
-      - name: Upload digest
-        if: matrix.OS == 'ubuntu-latest'
-        uses: actions/upload-artifact@v3
-        with:
-          name: digests
-          path: /tmp/digests/*
-          if-no-files-found: error
-          retention-days: 1
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.uploaded_filename }}
@@ -125,20 +64,27 @@ jobs:
       #   env:
       #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       #   run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ matrix.local_path }}
-  package-arm:
+  package-linux:
     # needs: [release-please]
     # if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
         OS: ["ubuntu-latest"]
-        include:
-          - os: ubuntu-latest
-            uploaded_filename: tgtg.jar
-            local_path: artifacts/tgtg.jar
         platform:
+          - linux/amd64
           - linux/arm/v7
           - linux/arm64/v8
+        include:
+          - platform: linux/amd64
+            uploaded_filename: tgtg-x86_64-pc-linux
+            local_path: artifacts/tgtg-x86_64-pc-linux
+          - platform: linux/arm/v7
+            uploaded_filename: tgtg.jar
+            local_path: artifacts/tgtg.jar
+          - platform: linux/arm64/v8
+            uploaded_filename: tgtg.jar
+            local_path: artifacts/tgtg.jar
     steps:
       - uses: actions/checkout@v3
         with:
@@ -156,27 +102,30 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          # type=raw,value=${{ needs.release-please.outputs.tag_name }}
-          tags: |
-            type=schedule
-            type=ref,event=branch
-            type=ref,event=tag
-            type=ref,event=pr
-            type=raw,value=latest
       - uses: coursier/cache-action@v6
       - uses: VirtusLab/scala-cli-setup@v1
         with:
           power: true
           jvm: "temurin:17"
       - name: Package app
+        if: matrix.platform == 'linux/amd64'
+        run: scala-cli package . -o "${{ matrix.local_path }}" --native-image -- -H:IncludeResources=version.txt --static
+      - name: Compress artifact
+        if: matrix.platform == 'linux/amd64'
+        uses: crazy-max/ghaction-upx@v2
+        with:
+          args: --best
+          files: ${{ matrix.local_path }}
+      - name: Package app
+        if: matrix.platform != 'linux/amd64'
         run: |
-          mkdir -p artifacts
+          mkdir -p $(dirname "${{  matrix.local_path }}")
           scala-cli package . -o "${{ matrix.local_path }}" --assembly
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         id: build
         with:
-          file: ./arm.Dockerfile
+          file: ${{ matrix.platform == 'linux/amd64' && './Dockerfile' || './arm.Dockerfile' }}
           build-args: "LOCAL_PATH=${{ matrix.local_path }}"
           context: .
           push: true
@@ -206,8 +155,7 @@ jobs:
   merge:
     runs-on: ubuntu-latest
     needs:
-      - package
-      - package-arm
+      - package-linux
     steps:
       - name: Download digests
         uses: actions/download-artifact@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -95,6 +95,7 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.uploaded_filename }}
@@ -112,7 +113,7 @@ jobs:
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: ${{ github.repository }}
-      DOCKER_TARGET_PLATFORM: linux/arm/v7
+      DOCKER_TARGET_PLATFORM: linux/arm/v7,linux/arm64/v8
     strategy:
       matrix:
         OS: ["ubuntu-latest"]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,6 +57,9 @@ jobs:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        if: matrix.OS == 'ubuntu-latest'
+        uses: docker/setup-buildx-action@v2
       - name: Extract metadata (tags, labels) for Docker
         if: matrix.OS == 'ubuntu-latest'
         id: meta
@@ -95,7 +98,6 @@ jobs:
           build-args: "LOCAL_PATH=${{ matrix.local_path }}"
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
@@ -178,7 +180,6 @@ jobs:
           build-args: "LOCAL_PATH=${{ matrix.local_path }}"
           context: .
           push: true
-          tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: ${{ matrix.platform }}
           outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
@@ -195,6 +196,7 @@ jobs:
           if-no-files-found: error
           retention-days: 1
       - uses: actions/upload-artifact@v3
+        if: matrix.platform == 'linux/arm64/v8' || matrix.platform == 'linux/amd64'
         with:
           name: ${{ matrix.uploaded_filename }}
           path: ${{ matrix.local_path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,3 +103,65 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ matrix.local_path }}
+  package-arm:
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created }}
+    runs-on: ${{ matrix.OS }}
+    env:
+      REGISTRY: ghcr.io
+      IMAGE_NAME: ${{ github.repository }}
+      DOCKER_TARGET_PLATFORM: linux/arm/v7
+    strategy:
+      matrix:
+        OS: ["ubuntu-latest"]
+        include:
+          - os: ubuntu-latest
+            uploaded_filename: tgtg.jar
+            local_path: artifacts/tgtg.jar
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=${{ needs.release-please.outputs.tag_name }}
+            type=raw,value=latest
+      - uses: coursier/cache-action@v6
+      - uses: VirtusLab/scala-cli-setup@v1
+        with:
+          power: true
+          jvm: "temurin:17"
+      - name: Package app
+        run: scala-cli package . -o "${{ matrix.local_path }}" --assembly
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v4
+        with:
+          file: ./arm.Dockerfile
+          build-args: "LOCAL_PATH=${{ matrix.local_path }}"
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: ${{ env.DOCKER_TARGET_PLATFORM }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: ${{ matrix.uploaded_filename }}
+          path: ${{ matrix.local_path }}
+          if-no-files-found: error
+          retention-days: 2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
-    types: [synchronize, opened, reopened]
 
 permissions:
   contents: write
@@ -17,21 +15,21 @@ env:
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
-  # release-please:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     release_created: ${{ steps.release.outputs.release_created }}
-  #     tag_name: ${{ steps.release.outputs.tag_name }}
-  #   steps:
-  #     - uses: google-github-actions/release-please-action@v3
-  #       id: release
-  #       with:
-  #         release-type: simple
-  #         package-name: tgtg
-  #         version-file: resources/version.txt
+  release-please:
+    runs-on: ubuntu-latest
+    outputs:
+      release_created: ${{ steps.release.outputs.release_created }}
+      tag_name: ${{ steps.release.outputs.tag_name }}
+    steps:
+      - uses: google-github-actions/release-please-action@v3
+        id: release
+        with:
+          release-type: simple
+          package-name: tgtg
+          version-file: resources/version.txt
   package:
-    # needs: [release-please]
-    # if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
@@ -60,13 +58,13 @@ jobs:
           path: ${{ matrix.local_path }}
           if-no-files-found: error
           retention-days: 2
-      # - name: Upload release artifacts
-      #   env:
-      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      #   run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ matrix.local_path }}
+      - name: Upload release artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ matrix.local_path }}
   package-linux:
-    # needs: [release-please]
-    # if: ${{ needs.release-please.outputs.release_created }}
+    needs: [release-please]
+    if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.OS }}
     strategy:
       matrix:
@@ -146,10 +144,16 @@ jobs:
           path: ${{ matrix.local_path }}
           if-no-files-found: error
           retention-days: 2
+      - name: Upload release artifacts
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ matrix.local_path }}
   # https://docs.docker.com/build/ci/github-actions/multi-platform/
   merge:
     runs-on: ubuntu-latest
+    if: ${{ needs.release-please.outputs.release_created }}
     needs:
+      - release-please
       - package-linux
     steps:
       - name: Download digests
@@ -164,12 +168,12 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY_IMAGE }}
-          # type=raw,value=${{ needs.release-please.outputs.tag_name }}
           tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
+            type=raw,value=${{ needs.release-please.outputs.tag_name }}
             type=raw,value=latest
       - name: Log in to the Container registry
         uses: docker/login-action@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ permissions:
 
 env:
   REGISTRY: ghcr.io
-  IMAGE_NAME: ${{ github.repository }}
   REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
 
 jobs:
@@ -51,6 +50,13 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Log in to the Container registry
+        if: matrix.OS == 'ubuntu-latest'
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         if: matrix.OS == 'ubuntu-latest'
         id: meta
@@ -135,6 +141,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Extract metadata (tags, labels) for Docker

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main
+  pull_request:
+    types: [synchronize, opened, reopened]
 
 permissions:
   contents: write
@@ -11,21 +13,21 @@ permissions:
   packages: write
 
 jobs:
-  release-please:
-    runs-on: ubuntu-latest
-    outputs:
-      release_created: ${{ steps.release.outputs.release_created }}
-      tag_name: ${{ steps.release.outputs.tag_name }}
-    steps:
-      - uses: google-github-actions/release-please-action@v3
-        id: release
-        with:
-          release-type: simple
-          package-name: tgtg
-          version-file: resources/version.txt
+  # release-please:
+  #   runs-on: ubuntu-latest
+  #   outputs:
+  #     release_created: ${{ steps.release.outputs.release_created }}
+  #     tag_name: ${{ steps.release.outputs.tag_name }}
+  #   steps:
+  #     - uses: google-github-actions/release-please-action@v3
+  #       id: release
+  #       with:
+  #         release-type: simple
+  #         package-name: tgtg
+  #         version-file: resources/version.txt
   package:
-    needs: [release-please]
-    if: ${{ needs.release-please.outputs.release_created }}
+    # needs: [release-please]
+    # if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.OS }}
     env:
       REGISTRY: ghcr.io
@@ -60,12 +62,12 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # type=raw,value=${{ needs.release-please.outputs.tag_name }}
           tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            type=raw,value=${{ needs.release-please.outputs.tag_name }}
             type=raw,value=latest
       - uses: coursier/cache-action@v6
       - uses: VirtusLab/scala-cli-setup@v1
@@ -99,13 +101,13 @@ jobs:
           path: ${{ matrix.local_path }}
           if-no-files-found: error
           retention-days: 2
-      - name: Upload release artifacts
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ matrix.local_path }}
+      # - name: Upload release artifacts
+      #   env:
+      #     GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      #   run: gh release upload ${{ needs.release-please.outputs.tag_name }} ${{ matrix.local_path }}
   package-arm:
-    needs: [release-please]
-    if: ${{ needs.release-please.outputs.release_created }}
+    # needs: [release-please]
+    # if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.OS }}
     env:
       REGISTRY: ghcr.io
@@ -135,12 +137,12 @@ jobs:
         uses: docker/metadata-action@v4
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          # type=raw,value=${{ needs.release-please.outputs.tag_name }}
           tags: |
             type=schedule
             type=ref,event=branch
             type=ref,event=tag
             type=ref,event=pr
-            type=raw,value=${{ needs.release-please.outputs.tag_name }}
             type=raw,value=latest
       - uses: coursier/cache-action@v6
       - uses: VirtusLab/scala-cli-setup@v1
@@ -148,7 +150,9 @@ jobs:
           power: true
           jvm: "temurin:17"
       - name: Package app
-        run: scala-cli package . -o "${{ matrix.local_path }}" --assembly
+        run: |
+          mkdir -p artifacts
+          scala-cli package . -o "${{ matrix.local_path }}" --assembly
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,6 +12,11 @@ permissions:
   pull-requests: write
   packages: write
 
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+  REGISTRY_IMAGE: ghcr.io/${{ github.repository }}
+
 jobs:
   # release-please:
   #   runs-on: ubuntu-latest
@@ -29,9 +34,6 @@ jobs:
     # needs: [release-please]
     # if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.OS }}
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
     strategy:
       matrix:
         OS: ["ubuntu-latest", "windows-latest", "macos-latest"]
@@ -49,19 +51,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Log in to the Container registry
-        if: matrix.OS == 'ubuntu-latest'
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         if: matrix.OS == 'ubuntu-latest'
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_IMAGE }}
           # type=raw,value=${{ needs.release-please.outputs.tag_name }}
           tags: |
             type=schedule
@@ -89,6 +84,7 @@ jobs:
       - name: Build and push Docker image
         if: matrix.OS == 'ubuntu-latest'
         uses: docker/build-push-action@v4
+        id: build
         with:
           build-args: "LOCAL_PATH=${{ matrix.local_path }}"
           context: .
@@ -96,6 +92,21 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           platforms: linux/amd64
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        if: matrix.OS == 'ubuntu-latest'
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        if: matrix.OS == 'ubuntu-latest'
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.uploaded_filename }}
@@ -110,10 +121,6 @@ jobs:
     # needs: [release-please]
     # if: ${{ needs.release-please.outputs.release_created }}
     runs-on: ${{ matrix.OS }}
-    env:
-      REGISTRY: ghcr.io
-      IMAGE_NAME: ${{ github.repository }}
-      DOCKER_TARGET_PLATFORM: linux/arm/v7,linux/arm64/v8
     strategy:
       matrix:
         OS: ["ubuntu-latest"]
@@ -121,23 +128,20 @@ jobs:
           - os: ubuntu-latest
             uploaded_filename: tgtg.jar
             local_path: artifacts/tgtg.jar
+        platform:
+          - linux/arm/v7
+          - linux/arm64/v8
     steps:
       - uses: actions/checkout@v3
         with:
           fetch-depth: 0
-      - name: Log in to the Container registry
-        uses: docker/login-action@v2
-        with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v4
         with:
-          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          images: ${{ env.REGISTRY_IMAGE }}
           # type=raw,value=${{ needs.release-please.outputs.tag_name }}
           tags: |
             type=schedule
@@ -156,6 +160,7 @@ jobs:
           scala-cli package . -o "${{ matrix.local_path }}" --assembly
       - name: Build and push Docker image
         uses: docker/build-push-action@v4
+        id: build
         with:
           file: ./arm.Dockerfile
           build-args: "LOCAL_PATH=${{ matrix.local_path }}"
@@ -163,10 +168,63 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: ${{ env.DOCKER_TARGET_PLATFORM }}
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY_IMAGE }},push-by-digest=true,name-canonical=true,push=true
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+      - name: Upload digest
+        uses: actions/upload-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
       - uses: actions/upload-artifact@v3
         with:
           name: ${{ matrix.uploaded_filename }}
           path: ${{ matrix.local_path }}
           if-no-files-found: error
           retention-days: 2
+  # https://docs.docker.com/build/ci/github-actions/multi-platform/
+  merge:
+    runs-on: ubuntu-latest
+    needs:
+      - package
+      - package-arm
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v3
+        with:
+          name: digests
+          path: /tmp/digests
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+      - name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v4
+        with:
+          images: ${{ env.REGISTRY_IMAGE }}
+          # type=raw,value=${{ needs.release-please.outputs.tag_name }}
+          tags: |
+            type=schedule
+            type=ref,event=branch
+            type=ref,event=tag
+            type=ref,event=pr
+            type=raw,value=latest
+      - name: Log in to the Container registry
+        uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY_IMAGE }}@sha256:%s ' *)
+      - name: Inspect image
+        run: |
+          docker buildx imagetools inspect ${{ env.REGISTRY_IMAGE }}:${{ steps.meta.outputs.version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,12 @@
 FROM busybox
 
-ARG LOCAL_PATH
+WORKDIR /opt/app
 
 ENV TINI_VERSION v0.19.0
 ADD https://github.com/krallin/tini/releases/download/${TINI_VERSION}/tini /tini
 RUN chmod +x /tini
 
-COPY ${LOCAL_PATH} tgtg 
-ENTRYPOINT ["/tini", "--", "/tgtg"]
+ARG LOCAL_PATH
+COPY ${LOCAL_PATH} tgtg
+
+ENTRYPOINT ["/tini", "--", "/opt/app/tgtg"]

--- a/arm.Dockerfile
+++ b/arm.Dockerfile
@@ -1,0 +1,10 @@
+ARG ARCH=
+FROM ${ARCH}eclipse-temurin:17
+
+WORKDIR /usr/src/app
+
+ARG LOCAL_PATH
+
+COPY ${LOCAL_PATH} tgtg.jar
+
+ENTRYPOINT ["java", "-jar", "tgtg.jar"]

--- a/arm.Dockerfile
+++ b/arm.Dockerfile
@@ -1,10 +1,9 @@
 ARG ARCH=
 FROM ${ARCH}eclipse-temurin:17
 
-WORKDIR /usr/src/app
+WORKDIR /opt/app
 
 ARG LOCAL_PATH
-
 COPY ${LOCAL_PATH} tgtg.jar
 
-ENTRYPOINT ["java", "-jar", "tgtg.jar"]
+ENTRYPOINT ["java", "-jar", "/opt/app/tgtg.jar"]


### PR DESCRIPTION
Fixes #37

ARM images cannot be statically linked, as there's no GraalVM for arm/v7, so the image is slightly bigger than the amd64 one.

Note: This only adds ARM docker containers, if you need a binary, use the `tgtg.jar` from the release 