### PR TITLE
fix: fix auth 403 by adding missing cookies

### DIFF
--- a/cache/FileCacheService.scala
+++ b/cache/FileCacheService.scala
@@ -1,6 +1,5 @@
 package tgtg.cache
 
-import cats.Functor
 import cats.effect.kernel.Clock
 import cats.effect.{IO, Ref, Resource}
 import cats.syntax.all.*
@@ -76,6 +75,6 @@ object FileCacheService:
 end FileCacheService
 
 // Copied from IO.realtimeInstant, which is not available in scala-js
-extension [F[_]: Functor](clock: Clock[F])
+extension [F[_]](clock: Clock[F])
   def instant: F[Instant] =
     clock.applicative.map(clock.realTime)(d => Instant.EPOCH.plusNanos(d.toNanos))

--- a/src/Config.scala
+++ b/src/Config.scala
@@ -2,7 +2,7 @@ package tgtg
 
 import cats.data.NonEmptyList
 import cats.syntax.all.*
-import com.comcast.ip4s.{Host, *}
+import com.comcast.ip4s.Host
 import com.monovore.decline.{Argument, Opts, Visibility}
 import cron4s.{Cron, CronExpr}
 import org.legogroup.woof.LogLevel

--- a/src/Model.scala
+++ b/src/Model.scala
@@ -61,6 +61,12 @@ case class Store(store_name: String) derives Decoder
 case class LoginRequest(email: Email, device_type: String = "ANDROID") derives Encoder.AsObject
 case class LoginResponse(state: String, polling_id: Option[String]) derives Decoder
 
+case class AnonymousEventPayload(
+    country_code: String,
+    uuid: String,
+    event_type: String
+) derives Encoder.AsObject
+
 case class PollRequest(email: Email, request_polling_id: String, device_type: String = "ANDROID")
     derives Encoder.AsObject
 


### PR DESCRIPTION
Send a request to the anonymousEvents endpoint to get the necessary cookies for authentication to bypass datadome protection.
